### PR TITLE
Fix broken links to the MIT web site

### DIFF
--- a/guide/091
+++ b/guide/091
@@ -183,7 +183,7 @@ Directed by Mike Vejar
    <li>@@@870986860 The title is from Shakespeare's
 	<a href="http://the-tech.mit.edu/Shakespeare/Tragedy/hamlet/hamlet.html">"Hamlet,"</a>
 	specifically Hamlet's speech in
-	<a href="http://the-tech.mit.edu/Shakespeare/Tragedy/hamlet/hamlet.2.2.html">act 2, scene 2:</a>
+	<a href="http://shakespeare.mit.edu/hamlet/hamlet.2.2.html">act 2, scene 2:</a>
 
 	<blockquote>
 	What a piece of work is a man!  How noble in reason!  How infinite

--- a/guide/092
+++ b/guide/092
@@ -141,7 +141,7 @@ Directed by Janet Greek
    <li>@@@887306823 Byron seems to be a
 	<a href="http://the-tech.mit.edu/Shakespeare/Tragedy/hamlet/hamlet.html">"Hamlet"</a>
 	fan; he quoted Hamlet's speech to Yorick's skull from
-	<a href="http://the-tech.mit.edu/Shakespeare/Tragedy/hamlet/hamlet.5.1.html">Act 5, Scene 1.</a>
+	<a href="http://shakespeare.mit.edu/hamlet/hamlet.5.1.html">Act 5, Scene 1.</a>
 
 </ul>
 

--- a/guide/107
+++ b/guide/107
@@ -276,7 +276,7 @@ Directed by Janet Greek
 
 <p>
    <li>@@@889493140 The title may be a reference to Shakespeare's "King Lear,"
-	<a href="http://the-tech.mit.edu/Shakespeare/Tragedy/kinglear/kinglear.4.7.html">act 4, scene 7:</a>
+	<a href="https://shakespeare.mit.edu/lear/lear.4.7.html">act 4, scene 7:</a>
 
 	<blockquote>
 	You do me wrong to take me out o' the grave:<br>


### PR DESCRIPTION
This PR fixes the links to the MIT website, which are broken since they changed the URL. 
However, the links to the index page of "Hamlet" are still broken due to the absence of these pages within the new MIT Shakespeare project web site structure.